### PR TITLE
Add SPM demo app (close #2)

### DIFF
--- a/demo/.scripts/carthage-workaround.sh
+++ b/demo/.scripts/carthage-workaround.sh
@@ -10,18 +10,11 @@ trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 
 # For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
 # the build will fail on lipo due to duplicate architectures.
-# Xcode 12 Beta 3:
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8169g = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-# Xcode 12 beta 4
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8179i = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-# Xcode 12 beta 5
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8189h = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-# Xcode 12 beta 6
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A8189n = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-# Xcode 12 GM (12A7208)
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7208 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-# Xcode 12 GM (12A7209)
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7209 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+
+CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+echo $CURRENT_XCODE_VERSION
+
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
 
 echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig

--- a/demo/.scripts/setup.sh
+++ b/demo/.scripts/setup.sh
@@ -17,7 +17,7 @@ BUILD_PROJECT_SWIFT_DEMO="-project SnowplowSwiftDemo.xcodeproj"
 BUILD_SCHEME_SWIFT_DEMO_IOS="-scheme SnowplowSwiftDemo"
 BUILD_SCHEME_SWIFT_DEMO_WATCH="-scheme SnowplowSwiftWatch"
 
-BUILD_PROJECT_SWIFT_SPM_DEMO="-project SnowplowSwiftSPMDemo.xcodeproj"
+BUILD_WORKSPACE_SWIFT_SPM_DEMO="-workspace SnowplowSwiftSPMDemo.xcworkspace"
 BUILD_SCHEME_SWIFT_SPM_DEMO_IOS="-scheme SnowplowSwiftSPMDemo"
 
 #if [ "$CI" = true ]; then

--- a/demo/.scripts/test_ios_demo.sh
+++ b/demo/.scripts/test_ios_demo.sh
@@ -1,23 +1,54 @@
 #!/usr/bin/env bash
 set -e
+set -x
 
-APP=$1
-DEP_FILE=$2
-PROJECT=$3
-DEST_IOS=$4
-SCHEME_IOS=$5
-DEST_WATCH=$6
-SCHEME_WATCH=$7
+echo $@
 
-if [ $DEP_FILE == "Cartfile" ]; then
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -podfile) DEP_TYPE="Cocoapods"; DEP_FILE="$2"; shift ;;
+        -carthage) DEP_TYPE="Carthage" ;;
+        -spm) DEP_TYPE="SPM"; DEP_BRANCH="$2"; shift ;;
+        -app) APP=$2; shift ;;
+        -ios) PROJECT=$2; DEST_IOS=$3; SCHEME_IOS=$4; shift; shift; shift ;;
+        -watch) DEST_WATCH=$2; SCHEME_WATCH=$3; shift; shift ;;
+		-log) LOGPATH=$2; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+echo DEP_TYPE $DEP_TYPE
+echo DEP_FILE $DEP_FILE
+echo DEP_BRANCH $DEP_BRANCH
+echo APP $APP
+echo PROJECT $PROJECT
+echo DEST_IOS $DEST_IOS
+echo SCHEME_IOS $SCHEME_IOS
+echo DEST_WATCH $DEST_WATCH
+echo SCHEME_WATCH $SCHEME_WATCH
+echo LOGPATH $LOGPATH
+
+#APP=$1
+#DEP_FILE=$2
+#PROJECT=$3
+#DEST_IOS=$4
+#SCHEME_IOS=$5
+#DEST_WATCH=$6
+#SCHEME_WATCH=$7
+
+if [ $DEP_TYPE == "Carthage" ]; then
 	. .scripts/carthage-workaround.sh # to remove when fixed https://github.com/Carthage/Carthage/issues/3019#issuecomment-665136323
 	printf "\n\n Carthage update \n"
 	cd $APP
 	./generateCartfile.sh
-	carthage update
-elif [ $DEP_FILE == "SPM" ]; then
-	printf "\n\n Swift Package Manager \n"
+	carthage update --log-path $LOGPATH
+elif [ $DEP_TYPE == "SPM" ]; then
+	printf "\n\n Swift Package Manager update \n"
 	cd $APP	
+	pushd Dependencies
+	sed -i .backup "s|master|$DEP_BRANCH|g" Package.swift
+	popd
 elif [ $DEP_FILE == "Podfile" ]; then
 	printf "\n\n Pod update \n"
 	cd $APP

--- a/demo/SnowplowSwiftSPMDemo/Dependencies/.gitignore
+++ b/demo/SnowplowSwiftSPMDemo/Dependencies/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/demo/SnowplowSwiftSPMDemo/Dependencies/Package.swift
+++ b/demo/SnowplowSwiftSPMDemo/Dependencies/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Dependencies",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Dependencies",
+            targets: ["Dependencies"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(name: "SnowplowTracker", url: "https://github.com/snowplow/snowplow-objc-tracker", .branch("master")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Dependencies",
+            dependencies: ["SnowplowTracker"]),
+    ]
+)

--- a/demo/SnowplowSwiftSPMDemo/Dependencies/Sources/Dependencies/Dependencies.swift
+++ b/demo/SnowplowSwiftSPMDemo/Dependencies/Sources/Dependencies/Dependencies.swift
@@ -1,0 +1,10 @@
+/*
+ NOTE: @_exported is an undisclosed feature not publicly supported.
+ It has been used to expose the dependency to the full app,
+ in order to make the SnowplowTracker dependency customizable by CI.
+ */
+@_exported import SnowplowTracker
+
+public struct Dependencies {
+    public var text = "Dummy text"
+}

--- a/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.pbxproj
+++ b/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,422 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CEF26A06243CC5630051C2EB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEF269F6243CC5630051C2EB /* LaunchScreen.storyboard */; };
+		CEF26A07243CC5630051C2EB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEF269F8243CC5630051C2EB /* Main.storyboard */; };
+		CEF26A08243CC5630051C2EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FA243CC5630051C2EB /* AppDelegate.swift */; };
+		CEF26A09243CC5630051C2EB /* DemoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FB243CC5630051C2EB /* DemoUtils.swift */; };
+		CEF26A0A243CC5630051C2EB /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FC243CC5630051C2EB /* PageViewController.swift */; };
+		CEF26A0B243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */; };
+		CEF26A0C243CC5630051C2EB /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FF243CC5630051C2EB /* DemoViewController.swift */; };
+		CEF26A0D243CC5630051C2EB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEF26A00243CC5630051C2EB /* Assets.xcassets */; };
+		CEF26A0F243CC5630051C2EB /* MetricsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A02243CC5630051C2EB /* MetricsViewController.swift */; };
+		CEF26A11243CC5630051C2EB /* AdditionalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A05243CC5630051C2EB /* AdditionalViewController.swift */; };
+		EDD53F61254069FA0000E57D /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = EDD53F60254069FA0000E57D /* Dependencies */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnowplowSwiftSPMDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CEF269EE243CC5450051C2EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CEF269F7243CC5630051C2EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		CEF269F9243CC5630051C2EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
+		CEF269FA243CC5630051C2EB /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = ../../CommonSwiftCode/AppDelegate.swift; sourceTree = "<group>"; };
+		CEF269FB243CC5630051C2EB /* DemoUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DemoUtils.swift; path = ../../CommonSwiftCode/DemoUtils.swift; sourceTree = "<group>"; };
+		CEF269FC243CC5630051C2EB /* PageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PageViewController.swift; path = ../../CommonSwiftCode/PageViewController.swift; sourceTree = "<group>"; };
+		CEF269FE243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SnowplowSwiftDemo.xcdatamodel; sourceTree = "<group>"; };
+		CEF269FF243CC5630051C2EB /* DemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DemoViewController.swift; path = ../../CommonSwiftCode/DemoViewController.swift; sourceTree = "<group>"; };
+		CEF26A00243CC5630051C2EB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = ../../CommonSwiftCode/Assets.xcassets; sourceTree = "<group>"; };
+		CEF26A02243CC5630051C2EB /* MetricsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MetricsViewController.swift; path = ../../CommonSwiftCode/MetricsViewController.swift; sourceTree = "<group>"; };
+		CEF26A04243CC5630051C2EB /* SnowplowSwiftDemo.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = SnowplowSwiftDemo.entitlements; path = ../../CommonSwiftCode/SnowplowSwiftDemo.entitlements; sourceTree = "<group>"; };
+		CEF26A05243CC5630051C2EB /* AdditionalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdditionalViewController.swift; path = ../../CommonSwiftCode/AdditionalViewController.swift; sourceTree = "<group>"; };
+		EDD53F5C254069380000E57D /* Dependencies */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Dependencies; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CEF269DA243CC5440051C2EB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EDD53F61254069FA0000E57D /* Dependencies in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CE57B9D7243CD152004C4941 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CEF269D4243CC5440051C2EB = {
+			isa = PBXGroup;
+			children = (
+				EDD53F5C254069380000E57D /* Dependencies */,
+				CEF269DE243CC5440051C2EB /* Products */,
+				CEF269DF243CC5440051C2EB /* SnowplowSwiftSPMDemo */,
+				CE57B9D7243CD152004C4941 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		CEF269DE243CC5440051C2EB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CEF269DF243CC5440051C2EB /* SnowplowSwiftSPMDemo */ = {
+			isa = PBXGroup;
+			children = (
+				CEF26A04243CC5630051C2EB /* SnowplowSwiftDemo.entitlements */,
+				CEF269EE243CC5450051C2EB /* Info.plist */,
+				CEF26A05243CC5630051C2EB /* AdditionalViewController.swift */,
+				CEF269FA243CC5630051C2EB /* AppDelegate.swift */,
+				CEF269FB243CC5630051C2EB /* DemoUtils.swift */,
+				CEF269FF243CC5630051C2EB /* DemoViewController.swift */,
+				CEF26A02243CC5630051C2EB /* MetricsViewController.swift */,
+				CEF269FC243CC5630051C2EB /* PageViewController.swift */,
+				CEF26A00243CC5630051C2EB /* Assets.xcassets */,
+				CEF269F5243CC5630051C2EB /* Base.lproj */,
+				CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */,
+			);
+			path = SnowplowSwiftSPMDemo;
+			sourceTree = "<group>";
+		};
+		CEF269F5243CC5630051C2EB /* Base.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				CEF269F6243CC5630051C2EB /* LaunchScreen.storyboard */,
+				CEF269F8243CC5630051C2EB /* Main.storyboard */,
+			);
+			name = Base.lproj;
+			path = ../../CommonSwiftCode/Base.lproj;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CEF269DC243CC5440051C2EB /* SnowplowSwiftSPMDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CEF269F1243CC5450051C2EB /* Build configuration list for PBXNativeTarget "SnowplowSwiftSPMDemo" */;
+			buildPhases = (
+				CEF269D9243CC5440051C2EB /* Sources */,
+				CEF269DA243CC5440051C2EB /* Frameworks */,
+				CEF269DB243CC5440051C2EB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EDD53F6325406A030000E57D /* PBXTargetDependency */,
+			);
+			name = SnowplowSwiftSPMDemo;
+			packageProductDependencies = (
+				EDD53F60254069FA0000E57D /* Dependencies */,
+			);
+			productName = SnowplowSwiftSPMDemo;
+			productReference = CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CEF269D5243CC5440051C2EB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1140;
+				LastUpgradeCheck = 1140;
+				ORGANIZATIONNAME = Snowplow;
+				TargetAttributes = {
+					CEF269DC243CC5440051C2EB = {
+						CreatedOnToolsVersion = 11.4;
+						LastSwiftMigration = 1140;
+					};
+				};
+			};
+			buildConfigurationList = CEF269D8243CC5440051C2EB /* Build configuration list for PBXProject "SnowplowSwiftSPMDemo" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CEF269D4243CC5440051C2EB;
+			packageReferences = (
+			);
+			productRefGroup = CEF269DE243CC5440051C2EB /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CEF269DC243CC5440051C2EB /* SnowplowSwiftSPMDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CEF269DB243CC5440051C2EB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CEF26A06243CC5630051C2EB /* LaunchScreen.storyboard in Resources */,
+				CEF26A0D243CC5630051C2EB /* Assets.xcassets in Resources */,
+				CEF26A07243CC5630051C2EB /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CEF269D9243CC5440051C2EB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CEF26A11243CC5630051C2EB /* AdditionalViewController.swift in Sources */,
+				CEF26A0A243CC5630051C2EB /* PageViewController.swift in Sources */,
+				CEF26A0B243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld in Sources */,
+				CEF26A09243CC5630051C2EB /* DemoUtils.swift in Sources */,
+				CEF26A0F243CC5630051C2EB /* MetricsViewController.swift in Sources */,
+				CEF26A08243CC5630051C2EB /* AppDelegate.swift in Sources */,
+				CEF26A0C243CC5630051C2EB /* DemoViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		EDD53F6325406A030000E57D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = EDD53F6225406A030000E57D /* Dependencies */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		CEF269F6243CC5630051C2EB /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CEF269F7243CC5630051C2EB /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		CEF269F8243CC5630051C2EB /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CEF269F9243CC5630051C2EB /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		CEF269EF243CC5450051C2EB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CEF269F0243CC5450051C2EB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CEF269F2243CC5450051C2EB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = SnowplowSwiftSPMDemo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.snowplowanalytics.SnowplowSwiftSPMDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CEF269F3243CC5450051C2EB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = SnowplowSwiftSPMDemo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.snowplowanalytics.SnowplowSwiftSPMDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CEF269D8243CC5440051C2EB /* Build configuration list for PBXProject "SnowplowSwiftSPMDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CEF269EF243CC5450051C2EB /* Debug */,
+				CEF269F0243CC5450051C2EB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CEF269F1243CC5450051C2EB /* Build configuration list for PBXNativeTarget "SnowplowSwiftSPMDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CEF269F2243CC5450051C2EB /* Debug */,
+				CEF269F3243CC5450051C2EB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		EDD53F60254069FA0000E57D /* Dependencies */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Dependencies;
+		};
+		EDD53F6225406A030000E57D /* Dependencies */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Dependencies;
+		};
+/* End XCSwiftPackageProductDependency section */
+
+/* Begin XCVersionGroup section */
+		CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				CEF269FE243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodel */,
+			);
+			currentVersion = CEF269FE243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodel */;
+			name = SnowplowSwiftDemo.xcdatamodeld;
+			path = ../../CommonSwiftCode/SnowplowSwiftDemo.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
+	};
+	rootObject = CEF269D5243CC5440051C2EB /* Project object */;
+}

--- a/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcworkspace/contents.xcworkspacedata
+++ b/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:SnowplowSwiftSPMDemo.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "FMDB",
+        "repositoryURL": "https://github.com/ccgus/fmdb",
+        "state": {
+          "branch": null,
+          "revision": "61e51fde7f7aab6554f30ab061cc588b28a97d04",
+          "version": "2.7.7"
+        }
+      },
+      {
+        "package": "SnowplowTracker",
+        "repositoryURL": "https://github.com/snowplow/snowplow-objc-tracker",
+        "state": {
+          "branch": "master",
+          "revision": "96dcf1586da7f901740f12b04a90d278a4bbfb79",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo/Info.plist
+++ b/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Added SPM demo app in order to test import of iOS tracker using Swift Package Manager as dependency manager.
The app uses an internal dummy package ("Dependency") in order to make the import of the iOS tracker configurable, otherwise it wouldn't be possible to change the git branch of the tracker to import.

Other minor changes have been added to the scripts in order to test the apps against the last Xcode 12.1 version.