### PR TITLE
Add a screen with a Web view that the tracker subscribe to events from

### DIFF
--- a/demo/CommonSwiftCode/Base.lproj/Main.storyboard
+++ b/demo/CommonSwiftCode/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BD3-Hb-Mgx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BD3-Hb-Mgx">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment version="4096" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment version="4352" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -60,7 +60,7 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Settings" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wwl-R4-ASv">
-                                                <rect key="frame" x="145" y="119.5" width="69" height="20.5"/>
+                                                <rect key="frame" x="145.5" y="119.5" width="68.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -329,7 +329,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="c8B-b0-hXd" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1167" y="116"/>
+            <point key="canvasLocation" x="546" y="116"/>
         </scene>
         <!--Pageview controller-->
         <scene sceneID="RMb-kq-vD5">
@@ -374,6 +374,65 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="18U-fq-eA0" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2088.8000000000002" y="115.59220389805098"/>
+        </scene>
+        <!--Web view controller-->
+        <scene sceneID="vgN-Wi-cnF">
+            <objects>
+                <viewController storyboardIdentifier="web" title="Web view controller" id="H0b-En-Nih" customClass="WebViewController" customModule="SnowplowSwiftSPMDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="VHI-JE-phD">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="GgQ-nW-HHt">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Web View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="egx-fm-Jnj">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Website URL" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Jep-oT-uTP">
+                                        <rect key="frame" x="0.0" y="20.5" width="375" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FHa-h5-o4h">
+                                        <rect key="frame" x="0.0" y="54.5" width="375" height="31"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Navigate"/>
+                                        <connections>
+                                            <action selector="navigatePressed:" destination="H0b-En-Nih" eventType="primaryActionTriggered" id="AaO-88-G9z"/>
+                                        </connections>
+                                    </button>
+                                    <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9d7-Iu-lpo">
+                                        <rect key="frame" x="0.0" y="85.5" width="375" height="581.5"/>
+                                        <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <wkWebViewConfiguration key="configuration">
+                                            <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                            <wkPreferences key="preferences"/>
+                                        </wkWebViewConfiguration>
+                                    </wkWebView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="twW-5D-Vk7"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="GgQ-nW-HHt" firstAttribute="centerY" secondItem="twW-5D-Vk7" secondAttribute="centerY" id="7GP-5I-gCP"/>
+                            <constraint firstItem="GgQ-nW-HHt" firstAttribute="width" secondItem="twW-5D-Vk7" secondAttribute="width" id="h2S-R2-Pcy"/>
+                            <constraint firstItem="GgQ-nW-HHt" firstAttribute="height" secondItem="twW-5D-Vk7" secondAttribute="height" id="ibl-Am-cgq"/>
+                            <constraint firstItem="GgQ-nW-HHt" firstAttribute="centerX" secondItem="twW-5D-Vk7" secondAttribute="centerX" id="m7S-nq-59d"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="urlField" destination="Jep-oT-uTP" id="xHQ-4M-edg"/>
+                        <outlet property="webView" destination="9d7-Iu-lpo" id="b5t-Yd-Xlu"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="huf-kH-qxr" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1334" y="116"/>
         </scene>
     </scenes>
     <resources>

--- a/demo/CommonSwiftCode/PageViewController.swift
+++ b/demo/CommonSwiftCode/PageViewController.swift
@@ -137,6 +137,7 @@ class PageViewController:  UIPageViewController, UIPageViewControllerDelegate, U
     lazy var orderedViewControllers: [UIViewController] = {
         return [self.newVc(viewController: "demo"),
                 self.newVc(viewController: "metrics"),
+                self.newVc(viewController: "web"),
                 self.newVc(viewController: "additional")]
     }()
 

--- a/demo/CommonSwiftCode/WebViewController.swift
+++ b/demo/CommonSwiftCode/WebViewController.swift
@@ -1,0 +1,40 @@
+//
+//  WebViewController.swift
+//  SnowplowSwiftSPMDemo
+//
+//  Created by Matus Tomlein on 07/07/2022.
+//  Copyright © 2022 Snowplow. All rights reserved.
+//
+
+import UIKit
+import WebKit
+import SnowplowTracker
+
+class WebViewController: UIViewController {
+    
+    @IBOutlet var webView: WKWebView!
+    @IBOutlet weak var urlField: UITextField!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        Snowplow.subscribeToWebViewEvents(with: webView.configuration)
+    }
+    
+    @IBAction func navigatePressed(_ sender: Any) {
+        if let urlText = urlField.text, let url = URL(string: urlText) {
+            webView.load(URLRequest(url: url))
+        }
+    }
+    
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/demo/CommonSwiftCode/WebViewController.swift
+++ b/demo/CommonSwiftCode/WebViewController.swift
@@ -1,9 +1,23 @@
 //
 //  WebViewController.swift
-//  SnowplowSwiftSPMDemo
+//  SnowplowSwiftDemo
 //
-//  Created by Matus Tomlein on 07/07/2022.
-//  Copyright © 2022 Snowplow. All rights reserved.
+//  Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Matus Tomlein
+//  Copyright: Copyright (c) 2015-2022 Snowplow Analytics Ltd
+//  License: Apache License Version 2.0
 //
 
 import UIKit
@@ -26,15 +40,5 @@ class WebViewController: UIViewController {
             webView.load(URLRequest(url: url))
         }
     }
-    
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.pbxproj
+++ b/demo/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6B07CDAA287709A500E510D6 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B07CDA9287709A500E510D6 /* WebViewController.swift */; };
 		CEF26A06243CC5630051C2EB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEF269F6243CC5630051C2EB /* LaunchScreen.storyboard */; };
 		CEF26A07243CC5630051C2EB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEF269F8243CC5630051C2EB /* Main.storyboard */; };
 		CEF26A08243CC5630051C2EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FA243CC5630051C2EB /* AppDelegate.swift */; };
@@ -21,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6B07CDA9287709A500E510D6 /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebViewController.swift; path = ../../CommonSwiftCode/WebViewController.swift; sourceTree = "<group>"; };
 		CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnowplowSwiftSPMDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEF269EE243CC5450051C2EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CEF269F7243CC5630051C2EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 				CEF26A00243CC5630051C2EB /* Assets.xcassets */,
 				CEF269F5243CC5630051C2EB /* Base.lproj */,
 				CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */,
+				6B07CDA9287709A500E510D6 /* WebViewController.swift */,
 			);
 			path = SnowplowSwiftSPMDemo;
 			sourceTree = "<group>";
@@ -187,6 +190,7 @@
 				CEF26A0F243CC5630051C2EB /* MetricsViewController.swift in Sources */,
 				CEF26A08243CC5630051C2EB /* AppDelegate.swift in Sources */,
 				CEF26A0C243CC5630051C2EB /* DemoViewController.swift in Sources */,
+				6B07CDAA287709A500E510D6 /* WebViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -339,6 +343,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = V487J8L84E;
 				INFOPLIST_FILE = SnowplowSwiftSPMDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -358,6 +363,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = V487J8L84E;
 				INFOPLIST_FILE = SnowplowSwiftSPMDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This change accompanies the [iOS tracker PR](https://github.com/snowplow/snowplow-objc-tracker/pull/692) that adds support for tracking events from Web views.

The change adds a new screen  to the app that shows a Web view and an address bar where users can navigate to some page to track events from.